### PR TITLE
モバイルでのスタイルを修正

### DIFF
--- a/src/components/Button.module.scss
+++ b/src/components/Button.module.scss
@@ -16,9 +16,9 @@
 
   @include mq(sm) {
     width: 100%;
-    height: 60px;
-    font-size: 24px;
-    line-height: 60px;
+    height: 50px;
+    font-size: 18px;
+    line-height: 50px;
   }
 }
 

--- a/src/components/Button.module.scss
+++ b/src/components/Button.module.scss
@@ -16,9 +16,7 @@
 
   @include mq(sm) {
     width: 100%;
-    height: 50px;
     font-size: 18px;
-    line-height: 50px;
   }
 }
 

--- a/src/components/Exam/ExamCard.module.scss
+++ b/src/components/Exam/ExamCard.module.scss
@@ -35,7 +35,7 @@
 
   @include mq(sm) {
     flex-direction: column;
-    row-gap: 30px;
+    row-gap: 20px;
     margin-top: 10px;
   }
 }
@@ -76,7 +76,7 @@
   }
 
   @include mq(sm) {
-    height: 200px;
+    height: 180px;
   }
 }
 

--- a/src/components/Exam/ExamCard.module.scss
+++ b/src/components/Exam/ExamCard.module.scss
@@ -15,8 +15,9 @@
   z-index: 20;
 
   @include mq(sm) {
+    position: fixed;
     width: 100vw;
-    height: 90vh;
+    height: 80%;
     top: auto;
     left: auto;
     bottom: 0;
@@ -87,6 +88,6 @@
   margin-top: 150px;
 
   @include mq(sm) {
-    margin-top: 90px;
+    margin-top: 60px;
   }
 }

--- a/src/components/Exam/ExamCard.module.scss
+++ b/src/components/Exam/ExamCard.module.scss
@@ -17,10 +17,10 @@
   @include mq(sm) {
     position: fixed;
     width: 100vw;
-    height: 80%;
-    top: auto;
+    height: auto;
+    top: var(--offsetY);
     left: auto;
-    bottom: 0;
+    bottom: auto;
     transform: none;
     -webkit-transform: none;
     -ms-transform: none;
@@ -35,7 +35,7 @@
 
   @include mq(sm) {
     flex-direction: column;
-    row-gap: 40px;
+    row-gap: 30px;
     margin-top: 10px;
   }
 }
@@ -88,6 +88,6 @@
   margin-top: 150px;
 
   @include mq(sm) {
-    margin-top: 60px;
+    margin-top: 40px;
   }
 }

--- a/src/components/Exam/ExamCard.tsx
+++ b/src/components/Exam/ExamCard.tsx
@@ -72,6 +72,9 @@ const ExamCard: React.FC<Props> = React.memo(
           {checked && !isLast && (
             <Button color="blue" text="次に進む" onClick={onClickNext} />
           )}
+          {checked && isLast && (
+            <Spacer size='50px' />
+          )}
           <Button color="gray" text="テストをやめる" onClick={onCloseModal} />
         </div>
       </div>

--- a/src/components/Exam/ExamCard.tsx
+++ b/src/components/Exam/ExamCard.tsx
@@ -4,6 +4,7 @@ import type { Card } from 'utils/types';
 
 import Button from 'components/Button';
 import styles from './ExamCard.module.scss';
+import Spacer from 'components/Spacer';
 
 type Props = {
   card: Card;
@@ -40,11 +41,15 @@ const ExamCard: React.FC<Props> = React.memo(
     // 画面の下に固定するため、どのくらい要素を下げるか計算する
     const [offsetY, setOffsetY] = React.useState<number>(0);
     React.useEffect(() => {
-      setOffsetY(viewHeight - contentHeight)
+      setOffsetY(viewHeight - contentHeight);
     }, [viewHeight, contentHeight]);
 
     return (
-      <div className={styles.modal} ref={cardSizeRef} style={{['--offsetY' as any]: `${offsetY}px`}}>
+      <div
+        className={styles.modal}
+        ref={cardSizeRef}
+        style={{ ['--offsetY' as any]: `${offsetY}px` }}
+      >
         <div className={styles.boxes}>
           <div className={styles.box_container}>
             <p>おもて</p>

--- a/src/components/Exam/ExamCard.tsx
+++ b/src/components/Exam/ExamCard.tsx
@@ -26,8 +26,25 @@ const ExamCard: React.FC<Props> = React.memo(
       onMoveNext();
     }, [onMoveNext]);
 
+    // アドレスバーなどを除いた表示領域の高さを取得
+    const viewHeight = React.useMemo(() => window.innerHeight, []);
+
+    // 表示コンテンツの高さを取得
+    const cardSizeRef = React.useRef<HTMLDivElement | null>(null);
+    const [contentHeight, setContentHeight] = React.useState<number>(0);
+    React.useEffect(() => {
+      if (!cardSizeRef.current) return;
+      setContentHeight(cardSizeRef.current.clientHeight);
+    }, [cardSizeRef]);
+
+    // 画面の下に固定するため、どのくらい要素を下げるか計算する
+    const [offsetY, setOffsetY] = React.useState<number>(0);
+    React.useEffect(() => {
+      setOffsetY(viewHeight - contentHeight)
+    }, [viewHeight, contentHeight]);
+
     return (
-      <div className={styles.modal}>
+      <div className={styles.modal} ref={cardSizeRef} style={{['--offsetY' as any]: `${offsetY}px`}}>
         <div className={styles.boxes}>
           <div className={styles.box_container}>
             <p>おもて</p>

--- a/src/components/Exam/ExamModal.tsx
+++ b/src/components/Exam/ExamModal.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import type { Card } from 'utils/types';
 import BlackFilter from 'components/BlackFilter';
 import ExamCard from './ExamCard';
+import useScrollLock from 'utils/useScrollLock';
 
 type Props = {
   examCardsList: Card[];
@@ -17,6 +18,8 @@ const ExamModal: React.FC<Props> = React.memo(
       () => setCardIndex((idx) => idx + 1),
       []
     );
+
+    useScrollLock(true);
 
     return (
       <>

--- a/src/components/Spacer.module.scss
+++ b/src/components/Spacer.module.scss
@@ -1,0 +1,5 @@
+.spacer {
+  display: block;
+  height: var(--size);
+  width: var(--size);
+}

--- a/src/components/Spacer.tsx
+++ b/src/components/Spacer.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import styles from './Spacer.module.scss';
+
+type Props = {
+  size: string;
+};
+
+const Spacer: React.FC<Props> = ({ size }) => {
+  return <div className={styles.spacer} style={{ ['--size' as any]: size }} />;
+};
+
+export default Spacer;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { AppProps } from 'next/app';
 
 import 'styles/global.scss';
 import styles from './_app.module.scss';
+import Spacer from 'components/Spacer';
 
 const MyApp = ({ Component, pageProps }: AppProps) => (
   <>
@@ -20,6 +21,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => (
     </nav>
     <main>
       <Component {...pageProps} />
+      <Spacer size='60px'/>
     </main>
   </>
 );

--- a/src/pages/exam/index.tsx
+++ b/src/pages/exam/index.tsx
@@ -10,6 +10,7 @@ import styles from './index.module.scss';
 
 import type { Card, Deck } from 'utils/types';
 import ExamModal from '../../components/Exam/ExamModal';
+import Spacer from 'components/Spacer';
 
 const Exam: React.FC = () => {
   const [decks, setDecks] = React.useState<Deck[]>([]);
@@ -80,12 +81,14 @@ const Exam: React.FC = () => {
           </div>
         </div>
         <div className={styles.buttons}>
-          {selectedDeck !== 0 && selectedMethod !== 0 && (
+          {selectedDeck !== 0 && selectedMethod !== 0 ? (
             <Button
               color="blue"
               text="スタート"
               onClick={() => setModal(true)}
             />
+          ) : (
+            <Spacer size="50px" />
           )}
           <Button color="gray" text="トップに戻る" onClick={onClickBack} />
         </div>

--- a/src/pages/exam/index.tsx
+++ b/src/pages/exam/index.tsx
@@ -42,13 +42,17 @@ const Exam: React.FC = () => {
   React.useEffect(() => {
     fetch('/api/cards')
       .then((res) => res.json())
-      .then((cards) => setCards(cards))
+      .then((cards) => setCards(cards));
   }, []);
 
   // テストするカードのリストを作成
   React.useEffect(() => {
-    const filteredCards = cards.filter((card: Card) => card.deck === selectedDeck);
-    setTestCards(() => selectedMethod === 1 ? shuffleArray(filteredCards) : filteredCards);
+    const filteredCards = cards.filter(
+      (card: Card) => card.deck === selectedDeck
+    );
+    setTestCards(() =>
+      selectedMethod === 1 ? shuffleArray(filteredCards) : filteredCards
+    );
   }, [cards, selectedDeck, selectedMethod]);
 
   return (
@@ -87,7 +91,9 @@ const Exam: React.FC = () => {
         </div>
       </div>
 
-      {modal && <ExamModal examCardsList={testCards} onCloseModal={onCloseModal} />}
+      {modal && (
+        <ExamModal examCardsList={testCards} onCloseModal={onCloseModal} />
+      )}
     </>
   );
 };

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -4,6 +4,9 @@
   display: flex;
   justify-content: center;
   margin-top: 50px;
+  @include mq(sm) {
+    margin-top: 30px;
+  }
 }
 
 .buttons {
@@ -15,7 +18,7 @@
   @include mq(sm) {
     flex-direction: column;
     margin-top: 50px;
-    row-gap: 40px;
+    row-gap: 30px;
   }
 }
 
@@ -36,10 +39,10 @@
 
   @include mq(sm) {
     width: 100%;
-    height: 60px;
+    height: 50px;
     border-radius: 4px;
-    font-size: 24px;
-    line-height: 60px;
+    font-size: 18px;
+    line-height: 50px;
   }
 }
 .button.primary {

--- a/src/utils/useScrollLock.tsx
+++ b/src/utils/useScrollLock.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+const useScrollLock = (lock: boolean) => {
+  React.useEffect(() => {
+    if (lock) {
+      const html = window.document.documentElement;
+      const scrollTop = html.scrollTop;
+
+      window.requestAnimationFrame(() => {
+        html.style.position = 'fixed';
+        html.style.overflow = 'hidden';
+        html.style.width = '100%';
+        html.style.top = `-${scrollTop}px`;
+      });
+
+      return () => {
+        window.requestAnimationFrame(() => {
+          html.style.position = '';
+          html.style.overflow = '';
+          html.style.width = '';
+          html.scrollTop = scrollTop;
+        });
+      }
+    }
+  }, [lock]);
+};
+
+export default useScrollLock;


### PR DESCRIPTION
モバイル実機でスタイルが崩れていたので修正

- モバイルブラウザのアドレスバーの影響でvh設定では上手くいかないので、JSで表示領域のサイズを計算してモーダルを表示
- Spacerを導入
- モーダル表示時のスクロールを禁止する